### PR TITLE
Kill jquery/ajax

### DIFF
--- a/app/controllers/repo/manage/slack.js
+++ b/app/controllers/repo/manage/slack.js
@@ -3,7 +3,6 @@ import { inject as service } from '@ember/service';
 import { alias } from '@ember/object/computed';
 
 export default Controller.extend({
-  ajax: service(),
   session: service(),
   slackSettings: alias('model'),
   actions: {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,10 +1,11 @@
 import { inject as service } from '@ember/service';
 import AbstractRoute from "client/routes/abstract-route";
+import { get } from 'client/utils/ajax';
 
 export default AbstractRoute.extend({
-  ajax: service(),
   session: service(),
   unAuthenticated: false,
+
   model(){
     return this.get('store').findAll('repo').catch( () => {
       this.transitionTo('login');
@@ -12,13 +13,13 @@ export default AbstractRoute.extend({
     });
   },
 
-  setupController(controller, model){
+  setupController(controller, model) {
     controller.set('model', model);
     controller.set('unAuthenticated', this.get('unAuthenticated'));
-    this.get('ajax').request('api/me').then( (results) => {
+    get('api/me').then( (results) => {
       this.set('session.user', results);
       controller.set('user', results);
-   });
+    });
   }
 
 });

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,11 +1,10 @@
 import AbstractRoute from "client/routes/abstract-route";
-import { inject as service } from '@ember/service';
+import { get } from 'client/utils/ajax';
 
 export default AbstractRoute.extend({
-  ajax: service(),
   title: 'Dashboard',
   model(/*params*/){
-    return this.get('ajax').request('api/me').then( (results) => {
+    return get('api/me').then( (results) => {
       return this.store.query('pullRequest',{reviewer: results.id});
    });
 

--- a/app/routes/repo/manage/index.js
+++ b/app/routes/repo/manage/index.js
@@ -1,8 +1,6 @@
-import { inject as service } from '@ember/service';
 import AbstractRoute from "client/routes/repo/manage/abstract-route";
 
 export default AbstractRoute.extend({
-  ajax: service(),
   model(/*params*/){
     return this.store.findRecord('repo', this.paramsFor('repo').repo_id);
   },

--- a/app/routes/repo/manage/members.js
+++ b/app/routes/repo/manage/members.js
@@ -1,8 +1,6 @@
-import { inject as service } from '@ember/service';
 import AbstractRoute from "client/routes/repo/manage/abstract-route";
 
 export default AbstractRoute.extend({
-  ajax: service(),
   model(/*params*/){
     return this.store.findRecord('repo', this.paramsFor('repo').repo_id);
   },

--- a/app/utils/ajax.js
+++ b/app/utils/ajax.js
@@ -6,7 +6,7 @@ function makeRequest (method, url) {
     xhr.open(method, url);
     xhr.onload = function () {
       if (this.status >= 200 && this.status < 300) {
-        resolve(xhr.response);
+        resolve(JSON.parse(xhr.response));
       } else {
         reject({
           status: this.status,

--- a/app/utils/ajax.js
+++ b/app/utils/ajax.js
@@ -1,0 +1,29 @@
+import RSVP from 'rsvp';
+
+function makeRequest (method, url) {
+  return new RSVP.Promise(function (resolve, reject) {
+    var xhr = new XMLHttpRequest();
+    xhr.open(method, url);
+    xhr.onload = function () {
+      if (this.status >= 200 && this.status < 300) {
+        resolve(xhr.response);
+      } else {
+        reject({
+          status: this.status,
+          statusText: xhr.statusText
+        });
+      }
+    };
+    xhr.onerror = function () {
+      reject({
+        status: this.status,
+        statusText: xhr.statusText
+      });
+    };
+    xhr.send();
+  });
+}
+
+export function get(url) {
+  return makeRequest('GET', url);
+}


### PR DESCRIPTION
Basically was talking to a friend at work about over usage of services so figured this are some pure functions that can be used with out DI, at the same time i need to do kill ic-ajax usage to kill jquery.

should prob use this lib https://github.com/ember-cli/ember-fetch. (probably a ton of code, cause why not)

Good thing about using the imports is that eslint can lint dead imports :)

