### PR TITLE
Refactor/componentize automation builder

### DIFF
--- a/app/components/automation-builder-iftt.js
+++ b/app/components/automation-builder-iftt.js
@@ -3,7 +3,7 @@ import { action } from '@ember-decorators/object';
 
 export default class AutomationBuilderIftt extends Component {
   @action
-  onDataUpdated(data) {
+  actionDataUpdated(data) {
     this.set('rule.rules.data', data);
   }
 

--- a/app/models/rule.js
+++ b/app/models/rule.js
@@ -1,10 +1,13 @@
 import DS from 'ember-data';
+import { attr, belongsTo } from '@ember-decorators/data';
 
-export default DS.Model.extend({
-  rules: DS.attr(),
-  conditions: DS.attr({ defaultValue() { return [{}]; } }),
-  event: DS.attr('string'),
-  createdAt: DS.attr('date'),
-  updatedAt: DS.attr('date'),
-  repo: DS.belongsTo('repo'),
-});
+const { Model } = DS;
+
+export default class Rule extends Model {
+  @attr('string') event;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
+  @attr() rules;
+  @attr('number', { defaultValue() { return [{}]; } }) conditions;
+  @belongsTo('repo') repo;
+}

--- a/app/models/rule.js
+++ b/app/models/rule.js
@@ -1,13 +1,26 @@
 import DS from 'ember-data';
 import { attr, belongsTo } from '@ember-decorators/data';
+import { service } from '@ember-decorators/service';
+import { computed } from '@ember-decorators/object';
 
 const { Model } = DS;
 
 export default class Rule extends Model {
+  @service automation;
   @attr('string') event;
   @attr('date') createdAt;
   @attr('date') updatedAt;
   @attr() rules;
   @attr('number', { defaultValue() { return [{}]; } }) conditions;
   @belongsTo('repo') repo;
+
+  @computed('event')
+  get eventSchema() {
+    return this.automation.eventHash[this.get('event')];
+  }
+
+  @computed('rules.action', 'eventSchema')
+  get actionSchema() {
+    return this.automation.actions.find(action => action.key === this.get('rules.action'));
+  }
 }

--- a/app/templates/components/action-picker.hbs
+++ b/app/templates/components/action-picker.hbs
@@ -1,0 +1,8 @@
+<PowerSelectBlockless
+  @options={{@availableActions}}
+  @selected={{@selectedAction}}
+  @labelPath="label"
+  @onchange={{@onActionSelected}}
+  class="ember-basic-dropdown"
+/>
+{{yield (component @selectedAction.editor)}}

--- a/app/templates/components/automation-builder-iftt.hbs
+++ b/app/templates/components/automation-builder-iftt.hbs
@@ -9,21 +9,20 @@
     </td>
   {{/if}}
   {{#if (and IFTT.action @rule.event)}}
-    {{#let (better-get @eventsHash @rule.event) as |eventDetails|}}
-      {{#let (find-by eventDetails.actions "key" @rule.rules.action) as |selectedAction|}}
-        <PowerSelectBlockless
-          @options={{eventDetails.actions}}
-          @selected={{selectedAction}}
-          @labelPath="label"
-          @onchange={{action "actionSelected"}}
-          class="ember-basic-dropdown"
-        />
-        {{component
-          selectedAction.editor
-          target=@target
-          onUpdated=(action "onDataUpdated")
-          data=@rule.rules.data
-        }}
+    {{#let (better-get @eventsHash @rule.event) as |selectedEventObject|}}
+      {{#let (find-by selectedEventObject.actions "key" @rule.rules.action) as |selectedAction|}}
+        <ActionPicker
+          @selectedAction={{selectedAction}}
+          @availableActions={{selectedEventObject.actions}}
+          @onActionSelected={{action "actionSelected"}}
+          @eventsHash={{@eventsHash}}
+        as |ActionEditor| >
+          <ActionEditor
+            @onActionDataUpdated={{action "actionDataUpdated"}}
+            @data={{@rule.rules.data}}
+            @target={{@target}}
+          />
+        </ActionPicker>
       {{/let}}
     {{/let}}
   {{/if}}

--- a/app/templates/components/automation-builder-iftt.hbs
+++ b/app/templates/components/automation-builder-iftt.hbs
@@ -2,9 +2,9 @@
   {{#if IFTT.eventPicker}}
     <td class="automation-title-container">
       <EventPicker
-      @selectedEvent={{@rule.event}}
-      @onEventSelected={{mut @rule.event}}
-      @eventsHash={{@eventsHash}}
+        @selectedEvent={{@rule.event}}
+        @onEventSelected={{mut @rule.event}}
+        @eventsHash={{@eventsHash}}
       />
     </td>
   {{/if}}

--- a/app/templates/components/automation-builder-iftt.hbs
+++ b/app/templates/components/automation-builder-iftt.hbs
@@ -9,22 +9,17 @@
     </td>
   {{/if}}
   {{#if (and IFTT.action @rule.event)}}
-    {{#let (better-get @eventsHash @rule.event) as |selectedEventObject|}}
-      {{#let (find-by selectedEventObject.actions "key" @rule.rules.action) as |selectedAction|}}
-        <ActionPicker
-          @selectedAction={{selectedAction}}
-          @availableActions={{selectedEventObject.actions}}
-          @onActionSelected={{action "actionSelected"}}
-          @eventsHash={{@eventsHash}}
-        as |ActionEditor| >
-          <ActionEditor
-            @onActionDataUpdated={{action "actionDataUpdated"}}
-            @data={{@rule.rules.data}}
-            @target={{@target}}
-          />
-        </ActionPicker>
-      {{/let}}
-    {{/let}}
+    <ActionPicker
+      @selectedAction={{@rule.actionSchema}}
+      @availableActions={{@rule.eventSchema.actions}}
+      @onActionSelected={{action "actionSelected"}}
+    as |ActionEditor| >
+      <ActionEditor
+        @onUpdated={{action "actionDataUpdated"}}
+        @data={{@rule.rules.data}}
+        @target={{@target}}
+      />
+    </ActionPicker>
   {{/if}}
   {{#if (and @rule.event IFTT.comparator)}}
     {{#each @rule.conditions as |condition|}}

--- a/app/templates/components/automation-builder-iftt.hbs
+++ b/app/templates/components/automation-builder-iftt.hbs
@@ -1,22 +1,11 @@
 <Iftt as |IFTT|>
   {{#if IFTT.eventPicker}}
     <td class="automation-title-container">
-      <BasicDropdown as |Dropdown|>
-        <Dropdown.trigger>
-          <h4 class="automation-title">
-            {{@rule.event}} {{fa-icon "caret-down"}}
-          </h4>
-        </Dropdown.trigger>
-        <Dropdown.content>
-          {{#each (object-keys @eventsHash) as |event|}}
-            <div class="automation-text-select">
-              <h4 class="automation-title" role="button" {{action (mut @rule.event) event}}>
-                {{event}}
-              </h4>
-            </div>
-          {{/each}}
-        </Dropdown.content>
-      </BasicDropdown>
+      <EventPicker
+      @selectedEvent={{@rule.event}}
+      @onEventSelected={{mut @rule.event}}
+      @eventsHash={{@eventsHash}}
+      />
     </td>
   {{/if}}
   {{#if (and IFTT.action @rule.event)}}

--- a/app/templates/components/event-picker.hbs
+++ b/app/templates/components/event-picker.hbs
@@ -1,0 +1,16 @@
+<BasicDropdown as |Dropdown|>
+  <Dropdown.trigger>
+    <h4 class="automation-title">
+      {{@selectedEvent}} {{fa-icon "caret-down"}}
+    </h4>
+  </Dropdown.trigger>
+  <Dropdown.content>
+    {{#each (object-keys @eventsHash) as |event|}}
+      <div class="automation-text-select">
+        <h4 class="automation-title" role="button" {{action @onEventSelected event}}>
+          {{event}}
+        </h4>
+      </div>
+    {{/each}}
+  </Dropdown.content>
+</BasicDropdown>

--- a/tests/integration/components/action-picker-test.js
+++ b/tests/integration/components/action-picker-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | action-picker', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{action-picker}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#action-picker}}
+        template block text
+      {{/action-picker}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/tests/integration/components/event-picker-test.js
+++ b/tests/integration/components/event-picker-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | event-picker', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{event-picker}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#event-picker}}
+        template block text
+      {{/event-picker}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});


### PR DESCRIPTION
First two commits are unfolding complexity to get up to the root level.

i then folded the complexity into the model.

The model has an attribute {rules}
```
{"data": {"label": "15"}, "action": "apply_label"}  
```

so since none are arrays i just doubled down on that to build the actionSchema property. the model def has to be looked at. it only supports one action and a multiple `and` conditions  at the moment.